### PR TITLE
Remove +1 to currentline update

### DIFF
--- a/src/pathview/GCodeSync.qml
+++ b/src/pathview/GCodeSync.qml
@@ -43,7 +43,8 @@ QtObject {
     function updateLine() {
         if (_ready) {
             var file = status.task.file
-            var currentLine = status.motion.motionLine + 1
+            var currentLine = status.motion.motionLine
+            
             if (_lastLine > currentLine) {
                 for (var line = 1; line <= _lastLine; ++line) {
                     model.setData(file, line, false, GCodeProgramModel.ExecutedRole)


### PR DESCRIPTION
Produces highlight of actual line in motion
in realtime

Signed-off-by: Mick Grant arceye@mgware.co.uk

Simply removing the increment seems to leave highlighting on the current motion line.
Not exhaustively tested, but works in sim on 3 different files, one of which uses conditional
loops iterating over same code, rather than linear top to bottom code
