### PR TITLE
ConnectionWindow: use list property again

### DIFF
--- a/src/applicationcontrols/ConnectionWindow.qml
+++ b/src/applicationcontrols/ConnectionWindow.qml
@@ -180,7 +180,7 @@ Rectangle {
 
     /*! This property holds the list of local applications.
     */
-    default property var applications: []
+    default property list<ApplicationDescription> applications
 
     /*!
         \qmlproperty Item toolBar


### PR DESCRIPTION
Turns out we need the list property, else the default property does not work.