### PR TITLE
machinetalkservice.cpp: gpb::vector -> std::vector

### DIFF
--- a/src/machinetalk/machinetalkservice.cpp
+++ b/src/machinetalk/machinetalkservice.cpp
@@ -115,7 +115,7 @@ int MachinetalkService::recurseMessage(const google::protobuf::Message &message,
     const bool filterEnabled = !fieldFilter.isEmpty();
     bool isPosition = false;
     const gpb::Reflection *reflection = message.GetReflection();
-    gpb::vector< const gpb::FieldDescriptor * > output;
+    std::vector< const gpb::FieldDescriptor * > output;
     reflection->ListFields(message, &output);
 
     if (message.GetDescriptor() == machinetalk::File::descriptor())  // handle files with binary data
@@ -190,7 +190,7 @@ void MachinetalkService::updateSimpleRepeatedField(QObject *object, const gpb::M
             list.append(QVariant());
         }
 
-        gpb::vector< const gpb::FieldDescriptor * > output;
+        std::vector< const gpb::FieldDescriptor * > output;
         subReflection->ListFields(subMessage, &output);
         if (output.size() > 1) // index and value field
         {


### PR DESCRIPTION
for newer protobuf compatibility
fixes https://github.com/machinekit/QtQuickVcp/issues/279