### PR TITLE
PathViewCore: add autoPreview property

### DIFF
--- a/src/pathview/PathViewCore.qml
+++ b/src/pathview/PathViewCore.qml
@@ -26,6 +26,15 @@ import Machinekit.PathView 1.0
 import Machinekit.Application 1.0
 
 ApplicationItem {
+    /*! If this property is set to \c{true}, the preview loads automatically when
+        the remote program is changed.
+        In some cases it might be preferred to update the preview manually, this can
+        be done using the \l updatePreview function.
+
+        The default value is \c{true}.
+    */
+    property bool autoPreview: true
+
     property alias gcodeProgramModel: gcodeProgramModel
     property alias gcodeProgramLoader: gcodeProgramLoader
     property alias previewClient: previewClient
@@ -87,7 +96,8 @@ ApplicationItem {
             if (previewEnabled
                 && (file.remoteFilePath !== "")
                 && (file.localFilePath !== "")
-                && (file.transferState === ApplicationFile.NoTransfer))
+                && (file.transferState === ApplicationFile.NoTransfer)
+                && autoPreview)
             {
                 executePreview();
             }
@@ -96,7 +106,7 @@ ApplicationItem {
         function reloadModelAndPreview() {
             gcodeProgramModel.clear();
             gcodeProgramLoader.load();
-            if (previewEnabled) {
+            if (previewEnabled && autoPreview) {
                 executePreview();
             }
         }


### PR DESCRIPTION
Adds an `autoPreview` property which enabled tighter control over the preview.