### PR TITLE
Add GitHub CI/CD for Linux, macOS, Windows

### DIFF
--- a/.github/workflows/builder-workflow.yaml
+++ b/.github/workflows/builder-workflow.yaml
@@ -1,0 +1,62 @@
+name: build Linux/macOS
+
+on:
+  push:
+    branches:
+    - '**'
+    tags-ignore:
+    - '*'
+
+jobs:
+  buildTest_x64:
+    name: Test_x64
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v2
+    - name: Install extra packages
+      run: |
+        sudo apt-get update        
+        sudo apt-get install bsdtar
+    - run: ./build/travis/job1_Test/build.sh --x86_64
+
+  buildAppImage_x64:
+    name: AppImage_x64
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v2
+    - name: Install extra packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install bsdtar
+    - run: ./build/travis/job2_AppImage/build.sh --x86_64
+    - name: Release
+      run: ./build/github/release.sh "$APP" "$LIB" "Linux 64bit"
+      env:
+        APP: '*x64.AppImage'
+        LIB: '*x64.tar.gz'
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  buildMacOS:
+    name: macOS
+    runs-on: macos-10.15
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v2
+    - run: echo "QT_SHORT_VERSION=5.8" >> $GITHUB_ENV
+    - run: echo "QT_LONG_VERSION=5.8.0" >> $GITHUB_ENV
+    - run: echo "QT_INSTALLER_ROOT=qt-opensource-mac-x64-clang-${QT_LONG_VERSION}" >> $GITHUB_ENV
+    - run: echo "QT_INSTALLER_FILENAME=${QT_INSTALLER_ROOT}.dmg" >> $GITHUB_ENV
+    - run: echo "QT_PATH=$HOME/qt" >> $GITHUB_ENV
+    - run: echo "QT_MACOS=$QT_PATH/$QT_SHORT_VERSION/clang_64" >> $GITHUB_ENV
+    - run: echo "$QT_MACOS/bin" >> $GITHUB_PATH
+    - run: echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
+    - run: ./build/travis/job_macos/install.sh
+    - run: ./build/travis/job_macos/build.sh
+    - name: Release
+      run: ./build/github/release.sh "$APP" "$LIB" "macOS 64bit"
+      env:
+        APP: '*x64.dmg'
+        LIB: '*x64.tar.gz'
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A remote UI implementation for [Machinekit](https://github.com/machinekit/machinekit) written in Qt/C++/QML. <a href="#contents">More info...</a>
 
-|   |  Travis CI | AppVeyor |
-|----------|:----:|:----:|
-| Build Status | [![Build Status](https://api.travis-ci.org/machinekit/QtQuickVcp.svg?branch=master)](http://travis-ci.org/machinekit/QtQuickVcp) | [![Build Status](https://ci.appveyor.com/api/projects/status/h8pi1hm0gj15nmgm?svg=true)](https://ci.appveyor.com/project/machinekoder/qtquickvcp) |
+|   |  Travis CI | AppVeyor | Github Actions |
+|----------|:----:|:----:|:----:|
+| Build Status | [![Build Status](https://api.travis-ci.org/machinekit/QtQuickVcp.svg?branch=master)](http://travis-ci.org/machinekit/QtQuickVcp) | [![Build Status](https://ci.appveyor.com/api/projects/status/h8pi1hm0gj15nmgm?svg=true)](https://ci.appveyor.com/project/machinekoder/qtquickvcp) | [![Build Status](https://github.com/machinekit/QtQuickVcp/actions/workflows/builder-workflow.yaml/badge.svg)](https://github.com/machinekit/QtQuickVcp/actions) |
 
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/10524/badge.svg)](https://scan.coverity.com/projects/qtquickvcp-qtquickvcp)
 
@@ -36,13 +36,13 @@ The MachinekitClient is available in following app stores:
 ### Rolling releases
 You can find rolling releases of the MachinekitClient and the QtQuickVcp library below. Stable releases have been dropped in favor of continuous deployment to decrease maintenance effort.
 
-| Operating System   |  MachinekitClient  | QtQuickVcp |
-|----------|:-------------:|:----:|
-| Windows 64bit  | [ ![Download](https://api.bintray.com/packages/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Windows-master-x64-signed/images/download.svg) ](https://bintray.com/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Windows-master-x64-signed/_latestVersion#files) | [ ![Download](https://api.bintray.com/packages/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Windows-master-x64/images/download.svg) ](https://bintray.com/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Windows-master-x64/_latestVersion#files) |
-| Windows 32bit  |  [ ![Download](https://api.bintray.com/packages/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Windows-master-x86-signed/images/download.svg) ](https://bintray.com/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Windows-master-x86-signed/_latestVersion#files) | [ ![Download](https://api.bintray.com/packages/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Windows-master-x86/images/download.svg) ](https://bintray.com/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Windows-master-x86/_latestVersion#files) |
-| Linux 64bit    | [ ![Download](https://api.bintray.com/packages/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Linux-master-x64/images/download.svg) ](https://bintray.com/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Linux-master-x64/_latestVersion#files) | [ ![Download](https://api.bintray.com/packages/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Linux-master-x64/images/download.svg) ](https://bintray.com/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Linux-master-x64/_latestVersion#files) |
-| Mac OS X 64bit | [ ![Download](https://api.bintray.com/packages/machinekoder/MachinekitClient-Development/MachinekitClient_Development-MacOSX-master-x64/images/download.svg) ](https://bintray.com/machinekoder/MachinekitClient-Development/MachinekitClient_Development-MacOSX-master-x64/_latestVersion#files) | [ ![Download](https://api.bintray.com/packages/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-MacOSX-master-x64/images/download.svg) ](https://bintray.com/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-MacOSX-master-x64/_latestVersion#files) |
-| Android armv7  | [ ![Download](https://api.bintray.com/packages/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Android-master-armv7/images/download.svg) ](https://bintray.com/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Android-master-armv7/_latestVersion#files) | [ ![Download](https://api.bintray.com/packages/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Android-master-armv7/images/download.svg) ](https://bintray.com/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Android-master-armv7/_latestVersion#files) |
+| Operating System   |  MachinekitClient and QtQuickVcp |
+|----------|:-----------------:|
+| Windows 64bit  | [ ![GitHub release (latest by date)](https://img.shields.io/github/v/release/machinekit/QtQuickVcp?label=x64%20zip&logo=github&style=for-the-badge) ](https://github.com/machinekit/QtQuickVcp/releases/latest) |
+| Windows 32bit  | [ ![GitHub release (latest by date)](https://img.shields.io/github/v/release/machinekit/QtQuickVcp?label=x86%20zip&logo=github&style=for-the-badge) ](https://github.com/machinekit/QtQuickVcp/releases/latest) |
+| Linux 64bit    | [ ![GitHub release (latest by date)](https://img.shields.io/github/v/release/machinekit/QtQuickVcp?label=x64&logo=github&style=for-the-badge) ](https://github.com/machinekit/QtQuickVcp/releases/latest) |
+| macOS 64bit    | [ ![GitHub release (latest by date)](https://img.shields.io/github/v/release/machinekit/QtQuickVcp?label=x64&logo=github&style=for-the-badge) ](https://github.com/machinekit/QtQuickVcp/releases/latest) |
+| Android armv7  | [ ![Download](https://api.bintray.com/packages/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Android-master-armv7/images/download.svg) ](https://bintray.com/machinekoder/MachinekitClient-Development/MachinekitClient_Development-Android-master-armv7/_latestVersion#files) [ ![Download](https://api.bintray.com/packages/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Android-master-armv7/images/download.svg) ](https://bintray.com/machinekoder/QtQuickVcp-Development/QtQuickVcp_Development-Android-master-armv7/_latestVersion#files) |
 
 **QtQuickVcp direct download links**
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,24 @@
 # http://www.appveyor.com/docs/build-configuration
 version: build{build}
 
+skip_tags: true
+
+image: Visual Studio 2015
+
 platform:
   - Win64
 
 environment:
+  global:
+    release_description: "
+      MachinekitClient_Development and QtQuickVcp_Development modules for
+      x64 (64-bit Intel/AMD) Linux systems (Portable AppImages),
+      Windows 32bit and 64bit (x86 zip and x64 zip),
+      x64 (64-bit Intel/AMD) MacOSX systems.
+      Automated builds of the master development branch. FOR TESTING PURPOSES ONLY!
+      Extract the contents of the archive to your Qt installation folder to use it.
+      "
+
   matrix:
    - QTDIR: C:\Qt\5.9\msvc2015_64
      VSVER: 14.0
@@ -18,6 +32,7 @@ configuration:
   - release
 
 install:
+  - ps: $env:release_tag = &git rev-parse --short $env:APPVEYOR_REPO_COMMIT
   - '%QTDIR%\bin\qtenv2.bat'
   - '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %ARCH%'
   - qmake -v
@@ -36,34 +51,24 @@ artifacts:
     name: QtQuickVcp-x64-archive
 
 deploy:
-- provider: BinTray
-  username: machinekoder
-  api_key:
-    secure: W+r/AcwTE6+ZntNkPg4ulGEWL9A51GF0UkCqT7OqS1OSLZZHrn9MUQdoODQulAaZ
-  subject: machinekoder
-  repo: QtQuickVcp-Development
-  package: QtQuickVcp_Development-Windows-master-x64
-  publish: true
-  override: true
-  explode: false
+- description: $(release_description)
+  provider: GitHub
+  auth_token:
+    secure: M9qlWKrBp+EjFfJen7YozWiJ1EjVaeLo2qfDKZsSgI4/X6N8HSub1cDTX4N6z/rk
   artifact: QtQuickVcp-x64-archive
-  version: $(appveyor_build_version)
+  tag: $(release_tag)
+  force_update: true
   on:
     branch: master
     appveyor_repo_tag: false
 
-- provider: BinTray
-  username: machinekoder
-  api_key:
-    secure: W+r/AcwTE6+ZntNkPg4ulGEWL9A51GF0UkCqT7OqS1OSLZZHrn9MUQdoODQulAaZ
-  subject: machinekoder
-  repo: MachinekitClient-Development
-  package: MachinekitClient_Development-Windows-master-x64
-  publish: true
-  override: true
-  explode: false
+- description: $(release_description)
+  provider: GitHub
+  auth_token:
+    secure: M9qlWKrBp+EjFfJen7YozWiJ1EjVaeLo2qfDKZsSgI4/X6N8HSub1cDTX4N6z/rk
   artifact: MachinekitClient-x64-archive
-  version: $(appveyor_build_version)
+  tag: $(release_tag)
+  force_update: true
   on:
     branch: master
     appveyor_repo_tag: false
@@ -98,34 +103,24 @@ deploy:
   on:
     appveyor_repo_tag: true
 
-- provider: BinTray
-  username: machinekoder
-  api_key:
-    secure: W+r/AcwTE6+ZntNkPg4ulGEWL9A51GF0UkCqT7OqS1OSLZZHrn9MUQdoODQulAaZ
-  subject: machinekoder
-  repo: QtQuickVcp-Development
-  package: QtQuickVcp_Development-Windows-master-x86
-  publish: true
-  override: true
-  explode: false
+- description: $(release_description)
+  provider: GitHub
+  auth_token:
+    secure: M9qlWKrBp+EjFfJen7YozWiJ1EjVaeLo2qfDKZsSgI4/X6N8HSub1cDTX4N6z/rk
   artifact: QtQuickVcp-x86-archive
-  version: $(appveyor_build_version)
+  tag: $(release_tag)
+  force_update: true
   on:
     branch: master
     appveyor_repo_tag: false
 
-- provider: BinTray
-  username: machinekoder
-  api_key:
-    secure: W+r/AcwTE6+ZntNkPg4ulGEWL9A51GF0UkCqT7OqS1OSLZZHrn9MUQdoODQulAaZ
-  subject: machinekoder
-  repo: MachinekitClient-Development
-  package: MachinekitClient_Development-Windows-master-x86
-  publish: true
-  override: true
-  explode: false
+- description: $(release_description)
+  provider: GitHub
+  auth_token:
+    secure: M9qlWKrBp+EjFfJen7YozWiJ1EjVaeLo2qfDKZsSgI4/X6N8HSub1cDTX4N6z/rk
   artifact: MachinekitClient-x86-archive
-  version: $(appveyor_build_version)
+  tag: $(release_tag)
+  force_update: true
   on:
     branch: master
     appveyor_repo_tag: false

--- a/build/github/release.sh
+++ b/build/github/release.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env sh
+
+APP="MachinekitClient_Development"
+LIB="QtQuickVcp_Development"
+APPNAME=$(find . -name "${APP}$1")
+TAGNAME=$(git rev-parse --short "$GITHUB_SHA")
+LIBNAME=$(find . -name "${LIB}$2")
+OS_ARCH=$3
+DESCRIPTION="${APP} and ${LIB} modules for:
+- x64 (64-bit Intel/AMD) Linux systems (Portable AppImages)
+- Windows 32bit and 64bit (x86 zip and x64 zip)
+- x64 (64-bit Intel/AMD) MacOSX systems
+Automated builds of the master development branch. FOR TESTING PURPOSES ONLY!
+Extract the contents of the archive to your Qt installation folder to use ${LIB}."
+
+gh release create "$TAGNAME" --notes "$DESCRIPTION" --title "$TAGNAME"
+gh release upload "$TAGNAME" "${APPNAME}#${APP} ${OS_ARCH}"
+gh release upload "$TAGNAME" "${LIBNAME}#${LIB} ${OS_ARCH}"

--- a/build/travis/job2_AppImage/build.sh
+++ b/build/travis/job2_AppImage/build.sh
@@ -80,21 +80,21 @@ if [ "${upload}" != "true" ]; then
         upload=true
     fi
     # skip pull requests
-    if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    if [ ! -z "${TRAVIS_PULL_REQUEST}" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         upload=
     fi
 fi
 
 if [ "${upload}" ]; then
     # rename binaries
-    # and upload AppImage to Bintray
     if [ $release -eq 1 ]; then
         target="QtQuickVcp"
     else
         target="QtQuickVcp_Development"
     fi
     mv build.release/QtQuickVcp.tar.gz ${target}-${version}-Linux-${platform}.tar.gz
-    ./build/travis/job2_AppImage/bintray_lib.sh ${target}-${version}*.tar.gz
+    # and upload AppImage to Bintray
+    # ./build/travis/job2_AppImage/bintray_lib.sh ${target}-${version}*.tar.gz
 
     if [ $release -eq 1 ]; then
         target="MachinekitClient"
@@ -102,7 +102,7 @@ if [ "${upload}" ]; then
         target="MachinekitClient_Development"
     fi
     mv build.release/MachinekitClient.AppImage ${target}-${version}-${platform}.AppImage
-    ./build/travis/job2_AppImage/bintray_app.sh ${target}*.AppImage
+    # ./build/travis/job2_AppImage/bintray_app.sh ${target}*.AppImage
 else
   echo "On branch '$branch' so AppImage will not be uploaded." >&2
 fi

--- a/build/travis/job_macos/build.sh
+++ b/build/travis/job_macos/build.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 # do not build mac for PR
-if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+if [ ! -z "${TRAVIS_PULL_REQUEST}" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   exit 0
 fi
 
@@ -88,21 +88,21 @@ if [ "${upload}" != "true" ]; then
     fi
     platform=x64
     # skip pull requests
-    if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    if [ ! -z "${TRAVIS_PULL_REQUEST}" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         upload=
     fi
 fi
 
 if [ "${upload}" ]; then
     # rename binaries
-    # and upload dmg to Bintray
     if [ $release -eq 1 ]; then
         target="QtQuickVcp"
     else
         target="QtQuickVcp_Development"
     fi
     mv build.release/QtQuickVcp.tar.gz ${target}-${version}-MacOSX-${platform}.tar.gz
-    ./build/travis/job_macos/bintray_lib.sh ${target}-${version}*.tar.gz
+    # and upload dmg to Bintray
+    # ./build/travis/job_macos/bintray_lib.sh ${target}-${version}*.tar.gz
 
     if [ $release -eq 1 ]; then
         target="MachinekitClient"
@@ -110,7 +110,7 @@ if [ "${upload}" ]; then
         target="MachinekitClient_Development"
     fi
     mv build.release/MachinekitClient.dmg ${target}-${version}-${platform}.dmg
-    ./build/travis/job_macos/bintray_app.sh ${target}*.dmg
+    # ./build/travis/job_macos/bintray_app.sh ${target}*.dmg
 else
   echo "On branch '$branch' so dmg will not be uploaded." >&2
 fi

--- a/build/travis/job_macos/install.sh
+++ b/build/travis/job_macos/install.sh
@@ -3,7 +3,7 @@
 set -x
 
 # do not build mac for PR
-if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+if [ ! -z "${TRAVIS_PULL_REQUEST}" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   exit 0
 fi
 
@@ -21,14 +21,14 @@ fi
 
 brew update
 brew install libtool automake autoconf pkg-config bash coreutils
-brew install gnu-sed --with-default-names
+brew install gnu-sed
 
 # install zeromq
 git clone https://github.com/zeromq/zeromq4-x.git
 cd zeromq4-x
 git checkout v4.0.8
 sh autogen.sh
-./configure --disable-static --enable-shared --prefix=/opt/local CC=clang CXX=clang++ CFLAGS="-arch x86_64" CXXFLAGS="-std=c++11 -stdlib=libstdc++ -O3 -arch x86_64" LDFLAGS="-stdlib=libstdc++"
+./configure --disable-static --enable-shared --prefix=/opt/local CC=clang CXX=clang CFLAGS="-arch x86_64" CXXFLAGS="-std=c++11 -stdlib=libc++ -O3 -arch x86_64" LDFLAGS="-stdlib=libc++"
 make
 sudo make install
 cd ..
@@ -76,7 +76,7 @@ echo "QT_LONG_VERSION QT_LONG_VERSION"
 if [[ "$QMAKE_VERSION" != "${QT_LONG_VERSION}" ]]; then
   rm -rf $QT_PATH
   echo "Downloading Qt"
-  wget -c --no-check-certificate -nv https://download.qt.io/archive/qt/${QT_SHORT_VERSION}/${QT_LONG_VERSION}/${QT_INSTALLER_FILENAME}
+  wget -c --no-check-certificate -nv https://download.qt.io/new_archive/qt/${QT_SHORT_VERSION}/${QT_LONG_VERSION}/${QT_INSTALLER_FILENAME}
   hdiutil mount ${QT_INSTALLER_FILENAME}
   cp -rf /Volumes/${QT_INSTALLER_ROOT}/${QT_INSTALLER_ROOT}.app $HOME/${QT_INSTALLER_ROOT}.app
   QT_INSTALLER_EXE=$HOME/${QT_INSTALLER_ROOT}.app/Contents/MacOS/${QT_INSTALLER_ROOT}


### PR DESCRIPTION
This adds a GitHub Action workflow to build on Linux and macOS.
Artifacts are deployed to GitHub Releases.
Also add small build fixes.
This is related to #298. 