### PR TITLE
TouchOffDialog: Align use of axisNames

### DIFF
--- a/src/applicationcontrols/TouchOffDialog.qml
+++ b/src/applicationcontrols/TouchOffDialog.qml
@@ -34,6 +34,7 @@ Dialog {
     property int axis: 0
     property var axisNames: helper.ready ? helper.axisNamesUpper : ["X", "Y", "Z"]
     property var _axisNames: helper.ready ? helper.axisNames : ["x", "y", "z"]
+    property int _index: helper.ready ? helper.axisIndices.indexOf(axis) : 0
 
     property bool _ready: status.synced && command.connected
     property bool _done: true
@@ -56,10 +57,10 @@ Dialog {
             if (status.task.taskMode !== ApplicationStatus.TaskModeMdi) {
                 command.setTaskMode('execute', ApplicationCommand.TaskModeMdi);
             }
-            var axisName = _axisNames[axis];
+            var axisName = _axisNames[_index];
             var position = status.motion.position[axisName] - status.motion.g92Offset[axisName] - status.io.toolOffset[axisName];
             var newOffset = (position - coordinateSpin.value);
-            var mdi = "G10 L2 P" + (coordinateSystemCombo.currentIndex + 1) + " " + axisNames[axis] + newOffset.toFixed(6);
+            var mdi = "G10 L2 P" + (coordinateSystemCombo.currentIndex + 1) + " " + axisNames[_index] + newOffset.toFixed(6);
             command.executeMdi('execute', mdi);
         }
 
@@ -69,7 +70,7 @@ Dialog {
     ColumnLayout {
         anchors.fill: parent
         Label {
-            text: qsTr("Enter %1 coordinate relative to workpiece:").arg(dialog.axisNames[dialog.axis])
+            text: qsTr("Enter %1 coordinate relative to workpiece:").arg(dialog.axisNames[dialog._index])
         }
         SpinBox {
             id: coordinateSpin


### PR DESCRIPTION
Z axis touch off on a lathe generates `G10 L2 P1 undefinedNaN` and returns the error: `Bad character ´u´ used`.
This PR aligns the use of axisNames in TouchOffDialog.qml with the use in [AxisRadioGroup.qml](https://github.com/machinekit/QtQuickVcp/blob/3863795fe811e06950f29056033845354abc534c/src/applicationcontrols/AxisRadioGroup.qml#L51) and [DigitalReadOut.qml](https://github.com/machinekit/QtQuickVcp/blob/master/src/applicationcontrols/DigitalReadOut.qml)
Tested under Windows, on a lathe.